### PR TITLE
Add persistent sessions and account switching flow

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -13,7 +13,7 @@
     </head>
     <body>
         <H1>User Login</H1>
-        <form action="user-login" method="post">
+        <form action="user-login{% if request.args.get('next') %}?next={{ request.args.get('next') }}{% endif %}" method="post">
             <div class="form-group">
                 User Name: <input type="text" name="user_name" required>
             </div>


### PR DESCRIPTION
- Add remember=True to login_user() calls for persistent sessions on mobile
- When accessing another user's resource, prompt to switch accounts instead of silently redirecting
- Preserve original URL and redirect there after successful login
- Add URL validation to prevent open redirect vulnerabilities